### PR TITLE
Fix issue : req.t not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,9 +195,10 @@ module.exports = (options) => {
     const selectedLocale = findBestLocale(queriedValues);
     setLocale(res, selectedLocale);
 
-    Object.keys(api(selectedLocale)).forEach(key => {
-      res.locals[key] = api[key];
-      req[key] = api[key];
+    let selectedApi = api(selectedLocale);
+    Object.keys(selectedApi).forEach(key => {
+      res.locals[key] = selectedApi[key];
+      req[key] = selectedApi[key];
     });
 
     next();


### PR DESCRIPTION
`api` was still the const function defined above when trying to `req[key] = api[key]`. Therefore it had no `key` index.